### PR TITLE
Add CUDNN 3 and 4 to the CUDA 7.0 images.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DOCKER_BIN ?= docker
 ifeq ($(OS), ubuntu)
 	CUDA_VERSIONS := 7.5 7.0 6.5
 else ifeq ($(OS), centos)
-        CUDA_VERSIONS := 7.5 7.0
+	CUDA_VERSIONS := 7.5 7.0
 else
 $(error unsupported OS: $(OS))
 endif
@@ -15,10 +15,10 @@ CUDA_LATEST := $(word 1, $(CUDA_VERSIONS))
 # cuDNN versions
 ifeq ($(OS), ubuntu)
 	CUDNN_VERSIONS := 7.5-cudnn4-devel 7.5-cudnn4-runtime \
-			  7.5-cudnn3-devel 7.5-cudnn3-runtime \
-			  	      7.0-cudnn4-devel 7.0-cudnn4-runtime \
-			  		  7.0-cudnn3-devel 7.0-cudnn3-runtime \
-	                  7.0-cudnn2-devel 7.0-cudnn2-runtime
+					7.5-cudnn3-devel 7.5-cudnn3-runtime \
+					7.0-cudnn4-devel 7.0-cudnn4-runtime \
+					7.0-cudnn3-devel 7.0-cudnn3-runtime \
+					7.0-cudnn2-devel 7.0-cudnn2-runtime
 endif
 CUDNN_DEVEL_LATEST := $(word 1, $(CUDNN_VERSIONS))
 CUDNN_RUNTIME_LATEST := $(word 2, $(CUDNN_VERSIONS))
@@ -86,7 +86,7 @@ push: all-cuda all-cudnn
 		echo "Error: USERNAME not set"; \
 		exit 1; \
 	fi; \
-        # Retag all images with the username as a prefix.
+	# Retag all images with the username as a prefix.
 	$(DOCKER_BIN) images | awk '$$1 == "cuda" { print $$2 }' | xargs -I {} $(DOCKER_BIN) tag -f cuda:{} $(USERNAME)/cuda:{}
 	$(DOCKER_BIN) push $(USERNAME)/cuda
 	$(DOCKER_BIN) images | awk '$$1 == "$(USERNAME)/cuda" { print $$2 }' | xargs -I {} $(DOCKER_BIN) rmi $(USERNAME)/cuda:{}

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ CUDA_LATEST := $(word 1, $(CUDA_VERSIONS))
 ifeq ($(OS), ubuntu)
 	CUDNN_VERSIONS := 7.5-cudnn4-devel 7.5-cudnn4-runtime \
 			  7.5-cudnn3-devel 7.5-cudnn3-runtime \
+			  	      7.0-cudnn4-devel 7.0-cudnn4-runtime \
+			  		  7.0-cudnn3-devel 7.0-cudnn3-runtime \
 	                  7.0-cudnn2-devel 7.0-cudnn2-runtime
 endif
 CUDNN_DEVEL_LATEST := $(word 1, $(CUDNN_VERSIONS))

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
 OS ?= ubuntu
+DOCKER_BIN ?= docker
 
 # CUDA versions
 ifeq ($(OS), ubuntu)
@@ -30,53 +31,53 @@ default: latest
 
 # CUDA images
 latest: devel
-	docker tag -f cuda:$< cuda
+	$(DOCKER_BIN) tag -f cuda:$< cuda
 
 devel: $(CUDA_LATEST)
-	docker tag -f cuda:$< cuda:$@
+	$(DOCKER_BIN) tag -f cuda:$< cuda:$@
 
 runtime: $(CUDA_LATEST)-runtime
-	docker tag -f cuda:$< cuda:$@
+	$(DOCKER_BIN) tag -f cuda:$< cuda:$@
 
 %: %-devel $(OS)/cuda/%
-	docker tag -f cuda:$< cuda:$@
+	$(DOCKER_BIN) tag -f cuda:$< cuda:$@
 
 %-devel: %-runtime $(OS)/cuda/%/devel/Dockerfile
-	docker build -t cuda:$@ $(OS)/cuda/$*/devel
+	$(DOCKER_BIN) build -t cuda:$@ $(OS)/cuda/$*/devel
 
 %-runtime: $(OS)/cuda/%/runtime/Dockerfile
-	docker build -t cuda:$@ $(OS)/cuda/$*/runtime
+	$(DOCKER_BIN) build -t cuda:$@ $(OS)/cuda/$*/runtime
 
 all-cuda: $(CUDA_VERSIONS) latest devel runtime
 
 # cuDNN images
 cudnn: cudnn-devel
-	docker tag -f cuda:$< cuda:$@
+	$(DOCKER_BIN) tag -f cuda:$< cuda:$@
 
 cudnn-devel: $(CUDNN_DEVEL_LATEST)
-	docker tag -f cuda:$< cuda:$@
+	$(DOCKER_BIN) tag -f cuda:$< cuda:$@
 
 cudnn-runtime: $(CUDNN_RUNTIME_LATEST)
-	docker tag -f cuda:$< cuda:$@
+	$(DOCKER_BIN) tag -f cuda:$< cuda:$@
 
 # Special rules for specific cuDNN versions
 %-cudnn2-devel: %-devel $(OS)/cuda/%/devel/cudnn2/Dockerfile
-	docker build -t cuda:$@ $(OS)/cuda/$*/devel/cudnn2
+	$(DOCKER_BIN) build -t cuda:$@ $(OS)/cuda/$*/devel/cudnn2
 
 %-cudnn2-runtime: %-runtime $(OS)/cuda/%/runtime/cudnn2/Dockerfile
-	docker build -t cuda:$@ $(OS)/cuda/$*/runtime/cudnn2
+	$(DOCKER_BIN) build -t cuda:$@ $(OS)/cuda/$*/runtime/cudnn2
 
 %-cudnn3-devel: %-devel $(OS)/cuda/%/devel/cudnn3/Dockerfile
-	docker build -t cuda:$@ $(OS)/cuda/$*/devel/cudnn3
+	$(DOCKER_BIN) build -t cuda:$@ $(OS)/cuda/$*/devel/cudnn3
 
 %-cudnn3-runtime: %-runtime $(OS)/cuda/%/runtime/cudnn3/Dockerfile
-	docker build -t cuda:$@ $(OS)/cuda/$*/runtime/cudnn3
+	$(DOCKER_BIN) build -t cuda:$@ $(OS)/cuda/$*/runtime/cudnn3
 
 %-cudnn4-devel: %-devel $(OS)/cuda/%/devel/cudnn4/Dockerfile
-	docker build -t cuda:$@ $(OS)/cuda/$*/devel/cudnn4
+	$(DOCKER_BIN) build -t cuda:$@ $(OS)/cuda/$*/devel/cudnn4
 
 %-cudnn4-runtime: %-runtime $(OS)/cuda/%/runtime/cudnn4/Dockerfile
-	docker build -t cuda:$@ $(OS)/cuda/$*/runtime/cudnn4
+	$(DOCKER_BIN) build -t cuda:$@ $(OS)/cuda/$*/runtime/cudnn4
 
 all-cudnn: $(CUDNN_VERSIONS) cudnn cudnn-devel cudnn-runtime
 
@@ -86,9 +87,9 @@ push: all-cuda all-cudnn
 		exit 1; \
 	fi; \
         # Retag all images with the username as a prefix.
-	docker images | awk '$$1 == "cuda" { print $$2 }' | xargs -I {} docker tag -f cuda:{} $(USERNAME)/cuda:{}
-	docker push $(USERNAME)/cuda
-	docker images | awk '$$1 == "$(USERNAME)/cuda" { print $$2 }' | xargs -I {} docker rmi $(USERNAME)/cuda:{}
+	$(DOCKER_BIN) images | awk '$$1 == "cuda" { print $$2 }' | xargs -I {} $(DOCKER_BIN) tag -f cuda:{} $(USERNAME)/cuda:{}
+	$(DOCKER_BIN) push $(USERNAME)/cuda
+	$(DOCKER_BIN) images | awk '$$1 == "$(USERNAME)/cuda" { print $$2 }' | xargs -I {} $(DOCKER_BIN) rmi $(USERNAME)/cuda:{}
 
 clean:
-	docker rmi -f `docker images -q --filter "label=com.nvidia.cuda.version"`
+	$(DOCKER_BIN) rmi -f `$(DOCKER_BIN) images -q --filter "label=com.nvidia.cuda.version"`

--- a/ubuntu-14.04/cuda/7.0/devel/cudnn3/Dockerfile
+++ b/ubuntu-14.04/cuda/7.0/devel/cudnn3/Dockerfile
@@ -1,0 +1,17 @@
+FROM cuda:7.0-devel
+MAINTAINER NVIDIA CORPORATION <digits@nvidia.com>
+
+RUN apt-get update && apt-get install -y \
+        curl && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV CUDNN_VERSION 3
+LABEL com.nvidia.cudnn.version="3"
+
+ENV CUDNN_DOWNLOAD_SUM 98679d5ec039acfd4d81b8bfdc6a6352d6439e921523ff9909d364e706275c2b
+
+RUN curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v3/cudnn-7.0-linux-x64-v3.0-prod.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM cudnn-7.0-linux-x64-v3.0-prod.tgz" | sha256sum -c --strict - && \
+    tar -xzf cudnn-7.0-linux-x64-v3.0-prod.tgz -C /usr/local && \
+    rm cudnn-7.0-linux-x64-v3.0-prod.tgz && \
+    ldconfig

--- a/ubuntu-14.04/cuda/7.0/devel/cudnn4/Dockerfile
+++ b/ubuntu-14.04/cuda/7.0/devel/cudnn4/Dockerfile
@@ -1,0 +1,17 @@
+FROM cuda:7.0-devel
+MAINTAINER NVIDIA CORPORATION <digits@nvidia.com>
+
+RUN apt-get update && apt-get install -y \
+        curl && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV CUDNN_VERSION 4
+LABEL com.nvidia.cudnn.version="4"
+
+ENV CUDNN_DOWNLOAD_SUM 4bcc67921018543e9066adb82ffd731f089eac80413e28eab6ae22a8bf5f4aaf
+
+RUN curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v4/cudnn-7.0-linux-x64-v4.0-rc.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM cudnn-7.0-linux-x64-v4.0-rc.tgz" | sha256sum -c --strict - && \
+    tar -xzf cudnn-7.0-linux-x64-v4.0-rc.tgz -C /usr/local && \
+    rm cudnn-7.0-linux-x64-v4.0-rc.tgz && \
+    ldconfig

--- a/ubuntu-14.04/cuda/7.0/runtime/cudnn3/Dockerfile
+++ b/ubuntu-14.04/cuda/7.0/runtime/cudnn3/Dockerfile
@@ -1,0 +1,17 @@
+FROM cuda:7.0-runtime
+MAINTAINER NVIDIA CORPORATION <digits@nvidia.com>
+
+RUN apt-get update && apt-get install -y \
+        curl && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV CUDNN_VERSION 3
+LABEL com.nvidia.cudnn.version="3"
+
+ENV CUDNN_DOWNLOAD_SUM 98679d5ec039acfd4d81b8bfdc6a6352d6439e921523ff9909d364e706275c2b
+
+RUN curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v3/cudnn-7.0-linux-x64-v3.0-prod.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM cudnn-7.0-linux-x64-v3.0-prod.tgz" | sha256sum -c --strict - && \
+    tar -xzf cudnn-7.0-linux-x64-v3.0-prod.tgz --wildcards 'cuda/lib64/libcudnn.so*' -C /usr/local && \
+    rm cudnn-7.0-linux-x64-v3.0-prod.tgz && \
+    ldconfig

--- a/ubuntu-14.04/cuda/7.0/runtime/cudnn4/Dockerfile
+++ b/ubuntu-14.04/cuda/7.0/runtime/cudnn4/Dockerfile
@@ -1,0 +1,17 @@
+FROM cuda:7.0-runtime
+MAINTAINER NVIDIA CORPORATION <digits@nvidia.com>
+
+RUN apt-get update && apt-get install -y \
+        curl && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV CUDNN_VERSION 4
+LABEL com.nvidia.cudnn.version="4"
+
+ENV CUDNN_DOWNLOAD_SUM 4bcc67921018543e9066adb82ffd731f089eac80413e28eab6ae22a8bf5f4aaf
+
+RUN curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v4/cudnn-7.0-linux-x64-v4.0-rc.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM cudnn-7.0-linux-x64-v4.0-rc.tgz" | sha256sum -c --strict - && \
+    tar -xzf cudnn-7.0-linux-x64-v4.0-rc.tgz --wildcards 'cuda/lib64/libcudnn.so*' -C /usr/local && \
+    rm cudnn-7.0-linux-x64-v4.0-rc.tgz && \
+    ldconfig


### PR DESCRIPTION
I have added Docker files for CUDNN 3 and 4 to the CUDA 7.0 images.

From the release notes, it seems as if CUDA 7.0 is the minimum requirements, and I run on a server where I am able to use Docker, but the drivers are not up to date for use with CUDA 7.5. I do, however, need CUDNN 3 (at least) for use with Caffe.

As a side note, there does seem to be quite a bit of duplication in the Docker files. Is there generation automated in some way?