### PR TITLE
Update to prevent useradd not unique uid error

### DIFF
--- a/tools/Dockerfile.build
+++ b/tools/Dockerfile.build
@@ -26,7 +26,7 @@ ENV CGO_CFLAGS "-I /usr/local/cuda-6.5/include -I /usr/include/nvidia/gdk"
 ENV CGO_LDFLAGS "-L /usr/local/cuda-6.5/lib64 -L /usr/src/gdk/nvml/lib -ldl -lrt"
 
 ARG UID
-RUN useradd --uid $UID build
+RUN useradd -o --uid $UID build
 USER build
 
 CMD go get -v -ldflags="-s" nvidia-docker nvidia-docker-plugin


### PR DESCRIPTION
Testing on fedora and arch linux led to the following error: 

useradd: UID 0 is not unique
The command '/bin/sh -c /bin/bash; useradd --uid $UID build' returned a non-zero code: 4
Makefile:18: recipe for target '/home/chief/nvidia-docker/tools/bin' failed

This allows for duplicate uid, which seems to be the same as current user(root=0), so that the following build steps succeed
