### PR TITLE
Implement cuDNN, Caffe(dev), Digits(dev) Dockerfiles for CentOS 7

### DIFF
--- a/centos-7/caffe/Dockerfile
+++ b/centos-7/caffe/Dockerfile
@@ -3,7 +3,10 @@ FROM cuda:7.0-cudnn4-devel
 ENV CAFFE_VERSION 0.14
 LABEL com.nvidia.caffe.version="0.14"
 
-ENV CAFFE_PKG_VERSION 0.14.0~rc.3-1
+# Install fpm and rpmrebuild
+RUN yum install -y epel-release
+RUN rpm --import http://li.nux.ro/download/nux/RPM-GPG-KEY-nux.ro
+RUN rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
 
 # Install build essential
 RUN yum update -y && yum install -y \
@@ -13,7 +16,7 @@ RUN yum update -y && yum install -y \
 	rm -rf /var/cache/yum/*
 
 RUN yum update -y && yum install -y \
-	wget git cmake openblas-devel && \
+	wget git cmake make automake openblas-devel && \
 	rm -rf /var/cache/yum/*
 
 # Get source code

--- a/centos-7/caffe/Dockerfile
+++ b/centos-7/caffe/Dockerfile
@@ -1,0 +1,42 @@
+FROM cuda:7.0-cudnn4-devel
+
+ENV CAFFE_VERSION 0.14
+LABEL com.nvidia.caffe.version="0.14"
+
+ENV CAFFE_PKG_VERSION 0.14.0~rc.3-1
+
+# Install build essential
+RUN yum update -y && yum install -y \
+	protobuf-devel leveldb-devel snappy-devel \
+	opencv-devel boost-devel hdf5-devel \
+	gflags-devel glog-devel lmdb-devel && \
+	rm -rf /var/cache/yum/*
+
+RUN yum update -y && yum install -y \
+	wget git cmake openblas-devel && \
+	rm -rf /var/cache/yum/*
+
+# Get source code
+ENV CAFFE_GIT https://github.com/NVIDIA/caffe.git
+ENV CAFFE_TAG v0.14.2
+ENV CAFFE_WS /tmp/caffe
+RUN git clone --single-branch -b $CAFFE_TAG $CAFFE_GIT $CAFFE_WS 
+
+# Get Python dependencies
+RUN yum update -y && yum install -y \
+	python-pip python-devel gcc-gfortran\
+	freetype-devel libpng-devel libjpeg-turbo-devel && \
+	rm -rf /var/cache/yum/*
+
+RUN pip install --upgrade pip
+
+# scipy
+
+RUN cd $CAFFE_WS/python && for req in $(cat requirements.txt); do pip install $req; done
+
+RUN mkdir -p $CAFFE_WS/build
+RUN cd $CAFFE_WS/build && \
+	cmake ../ -DCUDNN_ROOT=/usr/lib/x86_64-linux-gnu -DBLAS=open
+RUN cd $CAFFE_WS/build && \
+	make all && make install
+

--- a/centos-7/caffe/Makefile
+++ b/centos-7/caffe/Makefile
@@ -1,0 +1,3 @@
+# Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
+
+include ../../mk/caffe.mk

--- a/centos-7/cuda/7.0/devel/Dockerfile
+++ b/centos-7/cuda/7.0/devel/Dockerfile
@@ -6,6 +6,8 @@ RUN yum install -y \
         cuda-misc-headers-$CUDA_PKG_VERSION \
         cuda-command-line-tools-$CUDA_PKG_VERSION \
         cuda-license-$CUDA_PKG_VERSION \
+        cuda-nvrtc-dev-$CUDA_PKG_VERSION \
+        cuda-cusolver-dev-$CUDA_PKG_VERSION \
         cuda-cublas-dev-$CUDA_PKG_VERSION \
         cuda-cufft-dev-$CUDA_PKG_VERSION \
         cuda-curand-dev-$CUDA_PKG_VERSION \

--- a/centos-7/cuda/7.0/devel/cudnn4/Dockerfile
+++ b/centos-7/cuda/7.0/devel/cudnn4/Dockerfile
@@ -1,0 +1,50 @@
+FROM cuda:7.0-devel
+
+# Install fpm and rpmrebuild
+RUN yum install -y epel-release
+
+RUN rpm --import http://li.nux.ro/download/nux/RPM-GPG-KEY-nux.ro
+
+RUN rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
+
+RUN yum -y update && yum install -y \
+	ruby-devel gcc automake make rpmrebuild && \
+	rm -rf /var/cache/yum/*
+
+RUN gem install fpm
+
+# Download ML toolkit
+ENV NV_ROOT /tmp/nvtemp
+ENV NV_DL $NV_ROOT/download
+ENV NV_RPM $NV_ROOT/rpm
+ENV LIBCUDNN_DEB libcudnn4_4.0.7_amd64.deb
+ENV LIBCUDNN_ARCH x86_64
+ENV LIBCUDNN_RPM libcudnn4-4.0.7-1.x86_64.rpm
+
+RUN mkdir -p $NV_DL $NV_RPM
+RUN curl http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1404/x86_64/$LIBCUDNN_DEB -o $NV_DL/$LIBCUDNN_DEB
+
+# Transform to rpm
+RUN fpm -s deb -t rpm -p $NV_ROOT $NV_DL/$LIBCUDNN_DEB
+RUN rpmrebuild \
+	--change-spec-whole='sed -e "s|libc6.*|glibc|g" -e "s|libgcc1.*|libgcc|g" -e "s|libstdc++6.*|libstdc++|g"' \
+	-d $NV_RPM -p $NV_ROOT/$LIBCUDNN_RPM
+
+ENV CUDNN_VERSION 4
+LABEL com.nvidia.cudnn.version="4"
+
+RUN rpm -ivh $NV_RPM/$LIBCUDNN_ARCH/$LIBCUDNN_RPM
+
+# DEV part
+ENV LIBCUDNN_DEV_DEB libcudnn4-dev_4.0.7_amd64.deb
+ENV LIBCUDNN_DEV_RPM libcudnn4-dev-4.0.7-1.x86_64.rpm
+
+RUN curl http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1404/x86_64/$LIBCUDNN_DEV_DEB -o $NV_DL/$LIBCUDNN_DEV_DEB
+
+RUN fpm -s deb -t rpm -p $NV_ROOT $NV_DL/$LIBCUDNN_DEV_DEB
+RUN rpmrebuild \
+        --change-spec-whole='sed -e "s|libc6.*|glibc|g" -e "s|libgcc1.*|libgcc|g" -e "s|libstdc++6.*|libstdc++|g" -e "s|alternatives *--force|alternatives |g"' \
+        -d $NV_RPM -p $NV_ROOT/$LIBCUDNN_DEV_RPM
+
+RUN rpm -ivh $NV_RPM/$LIBCUDNN_ARCH/$LIBCUDNN_DEV_RPM
+

--- a/centos-7/cuda/7.0/devel/cudnn4/Dockerfile
+++ b/centos-7/cuda/7.0/devel/cudnn4/Dockerfile
@@ -1,50 +1,14 @@
 FROM cuda:7.0-devel
 
-# Install fpm and rpmrebuild
-RUN yum install -y epel-release
-
-RUN rpm --import http://li.nux.ro/download/nux/RPM-GPG-KEY-nux.ro
-
-RUN rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
-
-RUN yum -y update && yum install -y \
-	ruby-devel gcc automake make rpmrebuild && \
-	rm -rf /var/cache/yum/*
-
-RUN gem install fpm
-
-# Download ML toolkit
-ENV NV_ROOT /tmp/nvtemp
-ENV NV_DL $NV_ROOT/download
-ENV NV_RPM $NV_ROOT/rpm
-ENV LIBCUDNN_DEB libcudnn4_4.0.7_amd64.deb
-ENV LIBCUDNN_ARCH x86_64
-ENV LIBCUDNN_RPM libcudnn4-4.0.7-1.x86_64.rpm
-
-RUN mkdir -p $NV_DL $NV_RPM
-RUN curl http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1404/x86_64/$LIBCUDNN_DEB -o $NV_DL/$LIBCUDNN_DEB
-
-# Transform to rpm
-RUN fpm -s deb -t rpm -p $NV_ROOT $NV_DL/$LIBCUDNN_DEB
-RUN rpmrebuild \
-	--change-spec-whole='sed -e "s|libc6.*|glibc|g" -e "s|libgcc1.*|libgcc|g" -e "s|libstdc++6.*|libstdc++|g"' \
-	-d $NV_RPM -p $NV_ROOT/$LIBCUDNN_RPM
-
 ENV CUDNN_VERSION 4
 LABEL com.nvidia.cudnn.version="4"
 
-RUN rpm -ivh $NV_RPM/$LIBCUDNN_ARCH/$LIBCUDNN_RPM
+ENV CUDNN_DOWNLOAD_SUM 4e64ef7716f20c87854b4421863328e17cce633330c319b5e13809b61a36f97d
+ENV CUDNN_DOWNLOAD_FILENAME  cudnn-7.0-linux-x64-v4.0-prod.tgz
 
-# DEV part
-ENV LIBCUDNN_DEV_DEB libcudnn4-dev_4.0.7_amd64.deb
-ENV LIBCUDNN_DEV_RPM libcudnn4-dev-4.0.7-1.x86_64.rpm
-
-RUN curl http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1404/x86_64/$LIBCUDNN_DEV_DEB -o $NV_DL/$LIBCUDNN_DEV_DEB
-
-RUN fpm -s deb -t rpm -p $NV_ROOT $NV_DL/$LIBCUDNN_DEV_DEB
-RUN rpmrebuild \
-        --change-spec-whole='sed -e "s|libc6.*|glibc|g" -e "s|libgcc1.*|libgcc|g" -e "s|libstdc++6.*|libstdc++|g" -e "s|alternatives *--force|alternatives |g"' \
-        -d $NV_RPM -p $NV_ROOT/$LIBCUDNN_DEV_RPM
-
-RUN rpm -ivh $NV_RPM/$LIBCUDNN_ARCH/$LIBCUDNN_DEV_RPM
+RUN curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v4/$CUDNN_DOWNLOAD_FILENAME -O && \
+    echo "$CUDNN_DOWNLOAD_SUM $CUDNN_DOWNLOAD_FILENAME" | sha256sum -c --strict - && \
+    tar -xzf $CUDNN_DOWNLOAD_FILENAME -C /usr/local && \
+    rm $CUDNN_DOWNLOAD_FILENAME && \
+    ldconfig
 

--- a/centos-7/cuda/7.0/runtime/cudnn4/Dockerfile
+++ b/centos-7/cuda/7.0/runtime/cudnn4/Dockerfile
@@ -1,0 +1,37 @@
+FROM cuda:7.0-runtime
+
+# Install fpm and rpmrebuild
+RUN yum install -y epel-release
+
+RUN rpm --import http://li.nux.ro/download/nux/RPM-GPG-KEY-nux.ro
+
+RUN rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
+
+RUN yum -y update && yum install -y \
+	ruby-devel gcc automake make rpmrebuild && \
+	rm -rf /var/cache/yum/*
+
+RUN gem install fpm
+
+# Download ML toolkit
+ENV NV_ROOT /tmp/nvtemp
+ENV NV_DL $NV_ROOT/download
+ENV NV_RPM $NV_ROOT/rpm
+ENV LIBCUDNN_DEB libcudnn4_4.0.7_amd64.deb
+ENV LIBCUDNN_ARCH x86_64
+ENV LIBCUDNN_RPM libcudnn4-4.0.7-1.x86_64.rpm
+
+RUN mkdir -p $NV_DL $NV_RPM
+RUN curl http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1404/x86_64/$LIBCUDNN_DEB -o $NV_DL/$LIBCUDNN_DEB
+
+# Transform to rpm
+RUN fpm -s deb -t rpm -p $NV_ROOT $NV_DL/$LIBCUDNN_DEB
+RUN rpmrebuild \
+	--change-spec-whole='sed -e "s|libc6.*|glibc|g" -e "s|libgcc1.*|libgcc|g" -e "s|libstdc++6.*|libstdc++|g"' \
+	-d $NV_RPM -p $NV_ROOT/$LIBCUDNN_RPM
+
+ENV CUDNN_VERSION 4
+LABEL com.nvidia.cudnn.version="4"
+
+RUN rpm -ivh $NV_RPM/$LIBCUDNN_ARCH/$LIBCUDNN_RPM
+

--- a/centos-7/cuda/7.0/runtime/cudnn4/Dockerfile
+++ b/centos-7/cuda/7.0/runtime/cudnn4/Dockerfile
@@ -1,37 +1,13 @@
 FROM cuda:7.0-runtime
 
-# Install fpm and rpmrebuild
-RUN yum install -y epel-release
-
-RUN rpm --import http://li.nux.ro/download/nux/RPM-GPG-KEY-nux.ro
-
-RUN rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
-
-RUN yum -y update && yum install -y \
-	ruby-devel gcc automake make rpmrebuild && \
-	rm -rf /var/cache/yum/*
-
-RUN gem install fpm
-
-# Download ML toolkit
-ENV NV_ROOT /tmp/nvtemp
-ENV NV_DL $NV_ROOT/download
-ENV NV_RPM $NV_ROOT/rpm
-ENV LIBCUDNN_DEB libcudnn4_4.0.7_amd64.deb
-ENV LIBCUDNN_ARCH x86_64
-ENV LIBCUDNN_RPM libcudnn4-4.0.7-1.x86_64.rpm
-
-RUN mkdir -p $NV_DL $NV_RPM
-RUN curl http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1404/x86_64/$LIBCUDNN_DEB -o $NV_DL/$LIBCUDNN_DEB
-
-# Transform to rpm
-RUN fpm -s deb -t rpm -p $NV_ROOT $NV_DL/$LIBCUDNN_DEB
-RUN rpmrebuild \
-	--change-spec-whole='sed -e "s|libc6.*|glibc|g" -e "s|libgcc1.*|libgcc|g" -e "s|libstdc++6.*|libstdc++|g"' \
-	-d $NV_RPM -p $NV_ROOT/$LIBCUDNN_RPM
-
 ENV CUDNN_VERSION 4
 LABEL com.nvidia.cudnn.version="4"
 
-RUN rpm -ivh $NV_RPM/$LIBCUDNN_ARCH/$LIBCUDNN_RPM
+ENV CUDNN_DOWNLOAD_SUM 4e64ef7716f20c87854b4421863328e17cce633330c319b5e13809b61a36f97d
+ENV CUDNN_DOWNLOAD_FILENAME  cudnn-7.0-linux-x64-v4.0-prod.tgz
 
+RUN curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v4/$CUDNN_DOWNLOAD_FILENAME -O && \
+    echo "$CUDNN_DOWNLOAD_SUM $CUDNN_DOWNLOAD_FILENAME" | sha256sum -c --strict - && \
+    tar -xzf $CUDNN_DOWNLOAD_FILENAME --wildcards 'cuda/lib64/libcudnn.so*' -C /usr/local && \
+    rm $CUDNN_DOWNLOAD_FILENAME && \
+    ldconfig

--- a/centos-7/cuda/7.5/devel/Dockerfile
+++ b/centos-7/cuda/7.5/devel/Dockerfile
@@ -6,6 +6,8 @@ RUN yum install -y \
         cuda-misc-headers-$CUDA_PKG_VERSION \
         cuda-command-line-tools-$CUDA_PKG_VERSION \
         cuda-license-$CUDA_PKG_VERSION \
+        cuda-nvrtc-dev-$CUDA_PKG_VERSION \
+        cuda-cusolver-dev-$CUDA_PKG_VERSION \
         cuda-cublas-dev-$CUDA_PKG_VERSION \
         cuda-cufft-dev-$CUDA_PKG_VERSION \
         cuda-curand-dev-$CUDA_PKG_VERSION \

--- a/centos-7/cuda/7.5/devel/cudnn4/Dockerfile
+++ b/centos-7/cuda/7.5/devel/cudnn4/Dockerfile
@@ -1,0 +1,50 @@
+FROM cuda:7.5-devel
+
+# Install fpm and rpmrebuild
+RUN yum install -y epel-release
+
+RUN rpm --import http://li.nux.ro/download/nux/RPM-GPG-KEY-nux.ro
+
+RUN rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
+
+RUN yum -y update && yum install -y \
+	ruby-devel gcc automake make rpmrebuild && \
+	rm -rf /var/cache/yum/*
+
+RUN gem install fpm
+
+# Download ML toolkit
+ENV NV_ROOT /tmp/nvtemp
+ENV NV_DL $NV_ROOT/download
+ENV NV_RPM $NV_ROOT/rpm
+ENV LIBCUDNN_DEB libcudnn4_4.0.7_amd64.deb
+ENV LIBCUDNN_ARCH x86_64
+ENV LIBCUDNN_RPM libcudnn4-4.0.7-1.x86_64.rpm
+
+RUN mkdir -p $NV_DL $NV_RPM
+RUN curl http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1404/x86_64/$LIBCUDNN_DEB -o $NV_DL/$LIBCUDNN_DEB
+
+# Transform to rpm
+RUN fpm -s deb -t rpm -p $NV_ROOT $NV_DL/$LIBCUDNN_DEB
+RUN rpmrebuild \
+	--change-spec-whole='sed -e "s|libc6.*|glibc|g" -e "s|libgcc1.*|libgcc|g" -e "s|libstdc++6.*|libstdc++|g"' \
+	-d $NV_RPM -p $NV_ROOT/$LIBCUDNN_RPM
+
+ENV CUDNN_VERSION 4
+LABEL com.nvidia.cudnn.version="4"
+
+RUN rpm -ivh $NV_RPM/$LIBCUDNN_ARCH/$LIBCUDNN_RPM
+
+# DEV part
+ENV LIBCUDNN_DEV_DEB libcudnn4-dev_4.0.7_amd64.deb
+ENV LIBCUDNN_DEV_RPM libcudnn4-dev-4.0.7-1.x86_64.rpm
+
+RUN curl http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1404/x86_64/$LIBCUDNN_DEV_DEB -o $NV_DL/$LIBCUDNN_DEV_DEB
+
+RUN fpm -s deb -t rpm -p $NV_ROOT $NV_DL/$LIBCUDNN_DEV_DEB
+RUN rpmrebuild \
+        --change-spec-whole='sed -e "s|libc6.*|glibc|g" -e "s|libgcc1.*|libgcc|g" -e "s|libstdc++6.*|libstdc++|g" -e "s|alternatives *--force|alternatives |g"' \
+        -d $NV_RPM -p $NV_ROOT/$LIBCUDNN_DEV_RPM
+
+RUN rpm -ivh $NV_RPM/$LIBCUDNN_ARCH/$LIBCUDNN_DEV_RPM
+

--- a/centos-7/cuda/7.5/devel/cudnn4/Dockerfile
+++ b/centos-7/cuda/7.5/devel/cudnn4/Dockerfile
@@ -1,50 +1,13 @@
 FROM cuda:7.5-devel
 
-# Install fpm and rpmrebuild
-RUN yum install -y epel-release
-
-RUN rpm --import http://li.nux.ro/download/nux/RPM-GPG-KEY-nux.ro
-
-RUN rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
-
-RUN yum -y update && yum install -y \
-	ruby-devel gcc automake make rpmrebuild && \
-	rm -rf /var/cache/yum/*
-
-RUN gem install fpm
-
-# Download ML toolkit
-ENV NV_ROOT /tmp/nvtemp
-ENV NV_DL $NV_ROOT/download
-ENV NV_RPM $NV_ROOT/rpm
-ENV LIBCUDNN_DEB libcudnn4_4.0.7_amd64.deb
-ENV LIBCUDNN_ARCH x86_64
-ENV LIBCUDNN_RPM libcudnn4-4.0.7-1.x86_64.rpm
-
-RUN mkdir -p $NV_DL $NV_RPM
-RUN curl http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1404/x86_64/$LIBCUDNN_DEB -o $NV_DL/$LIBCUDNN_DEB
-
-# Transform to rpm
-RUN fpm -s deb -t rpm -p $NV_ROOT $NV_DL/$LIBCUDNN_DEB
-RUN rpmrebuild \
-	--change-spec-whole='sed -e "s|libc6.*|glibc|g" -e "s|libgcc1.*|libgcc|g" -e "s|libstdc++6.*|libstdc++|g"' \
-	-d $NV_RPM -p $NV_ROOT/$LIBCUDNN_RPM
-
 ENV CUDNN_VERSION 4
 LABEL com.nvidia.cudnn.version="4"
 
-RUN rpm -ivh $NV_RPM/$LIBCUDNN_ARCH/$LIBCUDNN_RPM
+ENV CUDNN_DOWNLOAD_SUM 4e64ef7716f20c87854b4421863328e17cce633330c319b5e13809b61a36f97d
+ENV CUDNN_DOWNLOAD_FILENAME  cudnn-7.0-linux-x64-v4.0-prod.tgz
 
-# DEV part
-ENV LIBCUDNN_DEV_DEB libcudnn4-dev_4.0.7_amd64.deb
-ENV LIBCUDNN_DEV_RPM libcudnn4-dev-4.0.7-1.x86_64.rpm
-
-RUN curl http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1404/x86_64/$LIBCUDNN_DEV_DEB -o $NV_DL/$LIBCUDNN_DEV_DEB
-
-RUN fpm -s deb -t rpm -p $NV_ROOT $NV_DL/$LIBCUDNN_DEV_DEB
-RUN rpmrebuild \
-        --change-spec-whole='sed -e "s|libc6.*|glibc|g" -e "s|libgcc1.*|libgcc|g" -e "s|libstdc++6.*|libstdc++|g" -e "s|alternatives *--force|alternatives |g"' \
-        -d $NV_RPM -p $NV_ROOT/$LIBCUDNN_DEV_RPM
-
-RUN rpm -ivh $NV_RPM/$LIBCUDNN_ARCH/$LIBCUDNN_DEV_RPM
-
+RUN curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v4/$CUDNN_DOWNLOAD_FILENAME -O && \
+    echo "$CUDNN_DOWNLOAD_SUM $CUDNN_DOWNLOAD_FILENAME" | sha256sum -c --strict - && \
+    tar -xzf $CUDNN_DOWNLOAD_FILENAME -C /usr/local && \
+    rm $CUDNN_DOWNLOAD_FILENAME && \
+    ldconfig

--- a/centos-7/cuda/7.5/runtime/cudnn4/Dockerfile
+++ b/centos-7/cuda/7.5/runtime/cudnn4/Dockerfile
@@ -1,0 +1,37 @@
+FROM cuda:7.5-runtime
+
+# Install fpm and rpmrebuild
+RUN yum install -y epel-release
+
+RUN rpm --import http://li.nux.ro/download/nux/RPM-GPG-KEY-nux.ro
+
+RUN rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
+
+RUN yum -y update && yum install -y \
+	ruby-devel gcc automake make rpmrebuild && \
+	rm -rf /var/cache/yum/*
+
+RUN gem install fpm
+
+# Download ML toolkit
+ENV NV_ROOT /tmp/nvtemp
+ENV NV_DL $NV_ROOT/download
+ENV NV_RPM $NV_ROOT/rpm
+ENV LIBCUDNN_DEB libcudnn4_4.0.7_amd64.deb
+ENV LIBCUDNN_ARCH x86_64
+ENV LIBCUDNN_RPM libcudnn4-4.0.7-1.x86_64.rpm
+
+RUN mkdir -p $NV_DL $NV_RPM
+RUN curl http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1404/x86_64/$LIBCUDNN_DEB -o $NV_DL/$LIBCUDNN_DEB
+
+# Transform to rpm
+RUN fpm -s deb -t rpm -p $NV_ROOT $NV_DL/$LIBCUDNN_DEB
+RUN rpmrebuild \
+	--change-spec-whole='sed -e "s|libc6.*|glibc|g" -e "s|libgcc1.*|libgcc|g" -e "s|libstdc++6.*|libstdc++|g"' \
+	-d $NV_RPM -p $NV_ROOT/$LIBCUDNN_RPM
+
+ENV CUDNN_VERSION 4
+LABEL com.nvidia.cudnn.version="4"
+
+RUN rpm -ivh $NV_RPM/$LIBCUDNN_ARCH/$LIBCUDNN_RPM
+

--- a/centos-7/cuda/7.5/runtime/cudnn4/Dockerfile
+++ b/centos-7/cuda/7.5/runtime/cudnn4/Dockerfile
@@ -1,37 +1,13 @@
 FROM cuda:7.5-runtime
 
-# Install fpm and rpmrebuild
-RUN yum install -y epel-release
-
-RUN rpm --import http://li.nux.ro/download/nux/RPM-GPG-KEY-nux.ro
-
-RUN rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
-
-RUN yum -y update && yum install -y \
-	ruby-devel gcc automake make rpmrebuild && \
-	rm -rf /var/cache/yum/*
-
-RUN gem install fpm
-
-# Download ML toolkit
-ENV NV_ROOT /tmp/nvtemp
-ENV NV_DL $NV_ROOT/download
-ENV NV_RPM $NV_ROOT/rpm
-ENV LIBCUDNN_DEB libcudnn4_4.0.7_amd64.deb
-ENV LIBCUDNN_ARCH x86_64
-ENV LIBCUDNN_RPM libcudnn4-4.0.7-1.x86_64.rpm
-
-RUN mkdir -p $NV_DL $NV_RPM
-RUN curl http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1404/x86_64/$LIBCUDNN_DEB -o $NV_DL/$LIBCUDNN_DEB
-
-# Transform to rpm
-RUN fpm -s deb -t rpm -p $NV_ROOT $NV_DL/$LIBCUDNN_DEB
-RUN rpmrebuild \
-	--change-spec-whole='sed -e "s|libc6.*|glibc|g" -e "s|libgcc1.*|libgcc|g" -e "s|libstdc++6.*|libstdc++|g"' \
-	-d $NV_RPM -p $NV_ROOT/$LIBCUDNN_RPM
-
 ENV CUDNN_VERSION 4
 LABEL com.nvidia.cudnn.version="4"
 
-RUN rpm -ivh $NV_RPM/$LIBCUDNN_ARCH/$LIBCUDNN_RPM
+ENV CUDNN_DOWNLOAD_SUM 4e64ef7716f20c87854b4421863328e17cce633330c319b5e13809b61a36f97d
+ENV CUDNN_DOWNLOAD_FILENAME  cudnn-7.0-linux-x64-v4.0-prod.tgz
 
+RUN curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v4/$CUDNN_DOWNLOAD_FILENAME -O && \
+    echo "$CUDNN_DOWNLOAD_SUM $CUDNN_DOWNLOAD_FILENAME" | sha256sum -c --strict - && \
+    tar -xzf $CUDNN_DOWNLOAD_FILENAME --wildcards 'cuda/lib64/libcudnn.so*' -C /usr/local && \
+    rm $CUDNN_DOWNLOAD_FILENAME && \
+    ldconfig

--- a/centos-7/cuda/Makefile
+++ b/centos-7/cuda/Makefile
@@ -3,6 +3,7 @@
 CUDA_VERSIONS := 7.5 \
                  7.0
 
-all-override: all-cuda
+CUDNN_VERSIONS := 7.5-cudnn4 \
+                  7.0-cudnn4
 
 include ../../mk/cuda.mk

--- a/centos-7/digits/Dockerfile
+++ b/centos-7/digits/Dockerfile
@@ -4,7 +4,6 @@ ENV DIGITS_VERSION 3.0
 LABEL com.nvidia.digits.version="3.0"
 
 # Install build essential
-ENV DIGITS_PKG_VERSION 3.0.0~rc.3-1
 RUN yum update -y && yum install -y \
 	graphviz 
 

--- a/centos-7/digits/Dockerfile
+++ b/centos-7/digits/Dockerfile
@@ -1,0 +1,34 @@
+FROM caffe
+
+ENV DIGITS_VERSION 3.0
+LABEL com.nvidia.digits.version="3.0"
+
+# Install build essential
+ENV DIGITS_PKG_VERSION 3.0.0~rc.3-1
+RUN yum update -y && yum install -y \
+	graphviz 
+
+# Get source code
+ENV DIGITS_GIT https://github.com/NVIDIA/DIGITS.git
+ENV DIGITS_TAG v3.0.0-rc.1
+ENV DIGITS_WS /tmp/digits
+RUN git clone --single-branch -b $DIGITS_TAG $DIGITS_GIT $DIGITS_WS 
+
+# Setup python packages
+RUN cd $DIGITS_WS && \
+	pip install -r requirements.txt
+
+# Fix issue of dependencies
+RUN pip install Flask-SocketIO==0.6.0
+# Fix issue of dependencies
+RUN pip install Flask-SocketIO==0.6.0
+
+RUN mkdir -p /var/log/digits
+RUN mkdir -p /usr/share/digits/digits/jobs
+
+RUN echo -e "[DIGITS]\ncaffe_root = /tmp/caffe\n" > $DIGITS_WS/digits/digits.cfg
+WORKDIR $DIGITS_WS
+
+# EXPOSE 34448
+# ENTRYPOINT ["./digits-devserver"]
+

--- a/centos-7/digits/Makefile
+++ b/centos-7/digits/Makefile
@@ -1,0 +1,3 @@
+# Copyright (c) 2016, NVIDIA CORPORATION. All rights reserved.
+
+include ../../mk/digits.mk


### PR DESCRIPTION
Hi, I've implemented some docker files which will help user using Digits under CentOS 7, but still need your kindly review to check these commits.
User can use DIGITS dev-server located in /tmp with these commits.

Following are some more detail about these commits
1. I install the cuDNN library with Ubuntu deb files. As far as I know, user have to register to Nvidia forum to get .rpm , hence I did some trick(transform .deb files to .rpm using ruby-fpm) to install Ubuntu deb files instead of asking user to get the files.
2. I build Caffe and DIGITS with these Dockerfiles instead of installing the .deb files provided by Nvidia directly. There are reasons to do this. First, both Caffe and DIGITS depends on many stuffs which might not as same as Ubuntu and their scripts inside .deb installation are incompatible to CentOS totally.

