### PR TITLE
Modify options handling to support Docker 1.10

### DIFF
--- a/tools/src/nvidia-docker/main.go
+++ b/tools/src/nvidia-docker/main.go
@@ -63,7 +63,7 @@ func main() {
 
 	command, i, err := docker.ParseArgs(args)
 	assert(err)
-	if command != "" {
+	if command == "create" || command == "run" || command == "volume" {
 		option, n, err = docker.ParseArgs(args[i+1:], command)
 		i += n + 1
 		assert(err)


### PR DESCRIPTION
Rely on a map of boolean flags for the three Docker commands we need
to parse, instead of using a regular expression on the output of
`docker help`.