### PR TITLE
Add cuDNN images for CentOS 6

### DIFF
--- a/centos-6/cuda/7.5/devel/cudnn5/Dockerfile
+++ b/centos-6/cuda/7.5/devel/cudnn5/Dockerfile
@@ -1,0 +1,12 @@
+FROM cuda:7.5-devel
+
+ENV CUDNN_VERSION 5
+LABEL com.nvidia.cudnn.version="5"
+
+ENV CUDNN_DOWNLOAD_SUM c4739a00608c3b66a004a74fc8e721848f9112c5cb15f730c1be4964b3a23b3a
+
+RUN curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v5/cudnn-7.5-linux-x64-v5.0-ga.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-7.5-linux-x64-v5.0-ga.tgz" | sha256sum -c --strict - && \
+    tar -xzf cudnn-7.5-linux-x64-v5.0-ga.tgz -C /usr/local && \
+    rm cudnn-7.5-linux-x64-v5.0-ga.tgz && \
+    ldconfig

--- a/centos-6/cuda/7.5/runtime/cudnn5/Dockerfile
+++ b/centos-6/cuda/7.5/runtime/cudnn5/Dockerfile
@@ -1,0 +1,12 @@
+FROM cuda:7.5-runtime
+
+ENV CUDNN_VERSION 5
+LABEL com.nvidia.cudnn.version="5"
+
+ENV CUDNN_DOWNLOAD_SUM c4739a00608c3b66a004a74fc8e721848f9112c5cb15f730c1be4964b3a23b3a
+
+RUN curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v5/cudnn-7.5-linux-x64-v5.0-ga.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-7.5-linux-x64-v5.0-ga.tgz" | sha256sum -c --strict - && \
+    tar -xzf cudnn-7.5-linux-x64-v5.0-ga.tgz -C /usr/local --wildcards 'cuda/lib64/libcudnn.so.*' && \
+    rm cudnn-7.5-linux-x64-v5.0-ga.tgz && \
+    ldconfig


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/nvidia-docker/issues/97

Given that there seems to be pretty old GLIBC compatibility for cuDNN, we should be able to just install the existing tarball of the binary here. So, this is what we try to do.

As I'm not an expert on how this stack works, I have tried my best to cobble something together that looks like it might work. Please let me know if there is anything I need to change.

This is totally untested. Not really sure what the workflow for that is here.