### PR TITLE
nvidia.go: ask if nvidia-modprobe is installed

### DIFF
--- a/tools/src/nvidia/nvidia.go
+++ b/tools/src/nvidia/nvidia.go
@@ -41,7 +41,7 @@ func LoadUVM() error {
 		return err
 	}
 	if exec.Command("nvidia-modprobe", "-u", "-c=0").Run() != nil {
-		return errors.New("Could not load UVM kernel module")
+		return errors.New("Could not load UVM kernel module. Is nvidia-modprobe installed?")
 	}
 	return nil
 }


### PR DESCRIPTION
Improve error message with hint about `nvidia-modprobe` being installed. Related to #125 