### PR TITLE
Update cudnn5-dev Dockerfile to avoid 5.0.6.

### DIFF
--- a/ubuntu-14.04/cuda/7.5/devel/cudnn5/Dockerfile
+++ b/ubuntu-14.04/cuda/7.5/devel/cudnn5/Dockerfile
@@ -7,5 +7,6 @@ ENV CUDNN_VERSION 5
 LABEL com.nvidia.cudnn.version="5"
 
 RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
+            libcudnn5=5.0.5-1+cuda7.5 \
             libcudnn5-dev=5.0.5-1+cuda7.5 && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The cudnn5-dev image build has been effectively broken for a while,
because -- while it specifies the version of the libcudnn5-dev headers
package precisely -- it then pulls in the most recent libcudnn5 (libs)
package.

Which has been 5.0.6 for about two weeks.

As a result, binaries built in this environment are inconsistent, having
been built against the headers for 5.0.5 but the libs for 5.0.6.
Tensorflow, in particular, contains explicit checks that detect this and
abort.