### PR TITLE
Add libEGL.so symlink

### DIFF
--- a/tools/src/nvidia/volumes.go
+++ b/tools/src/nvidia/volumes.go
@@ -268,6 +268,14 @@ func (v *Volume) Create(s FileCloneStrategy) (err error) {
 						return err
 					}
 				}
+				// XXX libcuda.so assumes that libEGL.so exists.
+				// Hardcode the libEGL symlink for the time being.
+				if strings.HasPrefix(soname[0], "libEGL") {
+					l = strings.TrimRight(l, ".0123456789")
+					if err := os.Symlink(path.Base(f), l); err != nil && !os.IsExist(err) {
+						return err
+					}
+				}
 				// XXX GLVND requires this symlink for indirect GLX support
 				// It won't be needed once we have an indirect GLX vendor neutral library.
 				if strings.HasPrefix(soname[0], "libGLX_nvidia") {


### PR DESCRIPTION
`libcuda` appears to dlopen `libEGL.so` instead of `libEGL.so.1`. Create this symlink to prevent segfaults in CUDA+OpenGL/EGL programs.

Without this patch, one workaround is to manually bring in `libEGL.so` from the host via

```
-v /usr/lib/nvidia-367/libEGL.so.1:/usr/lib/libEGL.so
```

OpenGL in a container with no running X dependency is nice :)

Related: #11 
