### PR TITLE
fix repository URL for CUDA 8.0 on Ubuntu 16.04

### DIFF
--- a/ubuntu-16.04/cuda/8.0/runtime/Dockerfile
+++ b/ubuntu-16.04/cuda/8.0/runtime/Dockerfile
@@ -8,7 +8,7 @@ RUN NVIDIA_GPGKEY_SUM=d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efac
     apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub && \
     apt-key adv --export --no-emit-version -a $NVIDIA_GPGKEY_FPR | tail -n +5 > cudasign.pub && \
     echo "$NVIDIA_GPGKEY_SUM  cudasign.pub" | sha256sum -c --strict - && rm cudasign.pub && \
-    echo "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1404/x86_64 /" > /etc/apt/sources.list.d/cuda.list
+    echo "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64 /" > /etc/apt/sources.list.d/cuda.list
 
 ENV CUDA_VERSION 8.0
 LABEL com.nvidia.cuda.version="8.0"


### PR DESCRIPTION
It was incorrectly left pointing to Ubuntu 14.04 repository in commit [Update CUDA 8.0 from RC to GA](https://github.com/NVIDIA/nvidia-docker/commit/81afc02d45edcd71c61fa3bad29dc0319e6d37c3#diff-780a304b7a61e7a7de17e22e526ba606R11).