### PR TITLE
Correct BUILD_ARCH usage

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -24,9 +24,9 @@ DOCKER_BIN := $(BIN_DIR)/nvidia-docker
 PLUGIN_BIN := $(BIN_DIR)/nvidia-docker-plugin
 
 # Mirror the BUILD_ARCH from the build Dockerfile
-BUILD_ARCH = $(shell uname -m)
-ifneq ($(BUILD_ARCH),ppc64le)
-    BUILD_ARCH = ''
+BUILD_ARCH = .$(shell uname -m)
+ifneq ($(BUILD_ARCH),.ppc64le)
+    BUILD_ARCH =
 else
 	PKG_ARCH = $(BUILD_ARCH)
 endif
@@ -56,7 +56,7 @@ ifneq ($(DOCKER_SUPPORTED),true)
 	$(error Unsupported Docker version)
 endif
 	@mkdir -p $(BIN_DIR)
-	@$(DOCKER_BUILD) -t $(PKG_NAME):$@ -f Dockerfile.$@.$(BUILD_ARCH) $(CURDIR)
+	@$(DOCKER_BUILD) -t $(PKG_NAME):$@ -f Dockerfile.$@$(BUILD_ARCH) $(CURDIR)
 	@$(DOCKER_RUN) -v $(BIN_DIR):/go/bin:Z $(PKG_NAME):$@
 
 install: build
@@ -84,7 +84,7 @@ deb: tarball
 ifneq ($(DOCKER_SUPPORTED),true)
 	$(error Unsupported Docker version)
 endif
-	@$(DOCKER_BUILD) -t $(PKG_NAME):$@ -f Dockerfile.$@.$(BUILD_ARCH) $(CURDIR)
+	@$(DOCKER_BUILD) -t $(PKG_NAME):$@ -f Dockerfile.$@$(BUILD_ARCH) $(CURDIR)
 	@$(DOCKER_RUN) -ti -v $(DIST_DIR):/dist -v $(BUILD_DIR):/build $(PKG_NAME):$@
 	@printf "\nFind packages at $(DIST_DIR)\n\n"
 
@@ -92,6 +92,6 @@ rpm: tarball
 ifneq ($(DOCKER_SUPPORTED),true)
 	$(error Unsupported Docker version)
 endif
-	@$(DOCKER_BUILD) -t $(PKG_NAME):$@ -f Dockerfile.$@.$(BUILD_ARCH) $(CURDIR)
+	@$(DOCKER_BUILD) -t $(PKG_NAME):$@ -f Dockerfile.$@$(BUILD_ARCH) $(CURDIR)
 	@$(DOCKER_RUN) -ti -v $(DIST_DIR):/dist -v $(BUILD_DIR):/build $(PKG_NAME):$@
 	@printf "\nFind packages at $(DIST_DIR)\n\n"


### PR DESCRIPTION
'make deb' didn't work on non-ppc64le platforms this way.

Signed-off-by: Christy Perez <christy@linux.vnet.ibm.com>