### PR TITLE
Add caffe for ppc64le

### DIFF
--- a/mk/caffe_ppc64le.mk
+++ b/mk/caffe_ppc64le.mk
@@ -2,8 +2,7 @@
 
 NV_DOCKER ?= docker
 
-CAFFE_VERSIONS := 0.15 \
-                  0.14
+CAFFE_VERSIONS := 0.14
 
 CAFFE_LATEST := $(word 1, $(CAFFE_VERSIONS))
 
@@ -18,10 +17,6 @@ all: $(CAFFE_VERSIONS) latest
 latest: $(CAFFE_LATEST)
 	$(NV_DOCKER) tag caffe:$< caffe
 
-0.15: $(CURDIR)/0.15/Dockerfile
-	make -C $(CURDIR)/../cuda 7.5-cudnn5-runtime
-	$(NV_DOCKER) build -t caffe:$@ $(CURDIR)/$@
-
-0.14: $(CURDIR)/0.14/Dockerfile
-	make -C $(CURDIR)/../cuda 7.5-cudnn5-runtime
-	$(NV_DOCKER) build -t caffe:$@ $(CURDIR)/$@
+0.14: $(CURDIR)/0.14/Dockerfile.ppc64le
+	make -C $(CURDIR)/../cuda 8.0-cudnn5-devel
+	$(NV_DOCKER) build -f $(CURDIR)/$@/Dockerfile.ppc64le -t caffe:$@ $(CURDIR)/$@

--- a/ubuntu-16.04/caffe/0.14/Dockerfile.ppc64le
+++ b/ubuntu-16.04/caffe/0.14/Dockerfile.ppc64le
@@ -1,0 +1,49 @@
+FROM cuda:8.0-cudnn5-devel
+MAINTAINER NVIDIA CORPORATION <digits@nvidia.com>
+
+ENV CAFFE_VERSION 0.14
+LABEL com.nvidia.caffe.version="0.14"
+
+ENV CAFFE_RELEASE v0.14.5-nv-ppc
+ENV CAFFE_ROOT /usr/local/caffe/
+ENV CAFFE_BIN $CAFFE_ROOT/build/install/bin
+ENV CAFFE_LIB $CAFFE_ROOT/build/install/lib
+
+ENV PATH $PATH:$CAFFE_BIN
+ENV PYTHONPATH $PYTHONPATH:$CAFFE_ROOT/build/install/python
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$CAFFE_LIB
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        g++ \
+        git \
+        liblapack-dev \
+        libboost-all-dev \
+        libopencv-dev \
+        cmake \
+        protobuf-compiler \
+        libprotobuf-dev \
+        libprotoc-dev \
+        libprotobuf-dev \
+        libatlas-base-dev \
+        libhdf5-serial-dev \
+        liblmdb-dev \
+        libleveldb-dev \
+        libsnappy-dev \
+        libgoogle-glog-dev \
+        libgflags-dev \
+        libsnappy-dev \
+        python-pip \
+        python-numpy && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install setuptools && \
+    pip install wheel && \
+    pip install scikit-image && \
+    pip install protobuf && \
+    git clone --branch $CAFFE_RELEASE https://github.com/ibmsoe/caffe $CAFFE_ROOT && \
+    cd $CAFFE_ROOT &&  \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make lib pycaffe tools && \
+    make install

--- a/ubuntu-16.04/caffe/Makefile
+++ b/ubuntu-16.04/caffe/Makefile
@@ -1,0 +1,12 @@
+# Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
+
+BUILD_ARCH = .$(shell uname -m)
+ifneq ($(BUILD_ARCH),.ppc64le)
+    BUILD_ARCH =
+endif
+
+ifeq ($(BUILD_ARCH), .ppc64le)
+    include ../../mk/caffe_ppc64le.mk
+else
+    $(warning "No ubuntu-16.04 caffe build target for the current archicture")
+endif


### PR DESCRIPTION
Builds on top of ubuntu 16.04 and cuda 8.0

Uses an empty dummy deb to get around a package dependency issue.

Maintains x86/amd interoperability.

Signed-off-by: Christy Perez <christy@linux.vnet.ibm.com>