### PR TITLE
Listen on all network interfaces by default

### DIFF
--- a/tools/build/common/nvidia-docker.service
+++ b/tools/build/common/nvidia-docker.service
@@ -15,7 +15,7 @@ RestartSec=1
 TimeoutStartSec=0
 TimeoutStopSec=20
 
-ExecStart=/usr/bin/nvidia-docker-plugin -s $SOCK_DIR
+ExecStart=/usr/bin/nvidia-docker-plugin -s $SOCK_DIR -l 0.0.0.0:3476
 ExecStartPost=/bin/sh -c '/bin/mkdir -p $( dirname $SPEC_FILE )'
 ExecStartPost=/bin/sh -c '/bin/echo unix://$SOCK_DIR/nvidia-docker.sock > $SPEC_FILE'
 ExecStopPost=/bin/rm -f $SPEC_FILE

--- a/tools/src/nvidia-docker-plugin/main.go
+++ b/tools/src/nvidia-docker-plugin/main.go
@@ -28,7 +28,7 @@ func init() {
 	log.SetPrefix(os.Args[0] + " | ")
 
 	flag.BoolVar(&PrintVersion, "v", false, "Show the plugin version information")
-	flag.StringVar(&ListenAddr, "l", "localhost:3476", "Server listen address")
+	flag.StringVar(&ListenAddr, "l", "0.0.0.0:3476", "Server listen address")
 	flag.StringVar(&VolumesPath, "d", "/var/lib/nvidia-docker/volumes", "Path where to store the volumes")
 	flag.StringVar(&SocketPath, "s", "/run/docker/plugins", "Path to the plugin socket")
 }


### PR DESCRIPTION
In Ubuntu it is a PITA to remember how to update the configuration options for systemd controlled services. imho it is a great service for docker engine users in ubuntu if the nvidia-docker restful api also listened on 0.0.0.0 by default, and users would not have to figure out how to make it listen on external interfaces as well.