### PR TITLE
Mount the nvidia_driver volume with 'z' option

### DIFF
--- a/src/nvidia/volumes.go
+++ b/src/nvidia/volumes.go
@@ -105,7 +105,7 @@ var Volumes = []VolumeInfo{
 	{
 		"nvidia_driver",
 		"/usr/local/nvidia",
-		"ro",
+		"ro,z",
 		components{
 			"binaries": {
 				//"nvidia-modprobe",       // Kernel module loader


### PR DESCRIPTION
Required to work with SELinux (See [docker documentation](https://docs.docker.com/engine/tutorials/dockervolumes/#/volume-labels))

I had issues using `nvidia-docker-plugin` on Fedora 25 and adding the 'z' option to the volume mount resolved the issue.  I was able to run with the `:ro,z` suffix to the volume mount on Ubuntu 16.04 that did not have SELinux.