### PR TITLE
Updated to work with Ubuntu 16.10

### DIFF
--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         vim-nox \


### PR DESCRIPTION
"make deb" works flawlessly; resulting deb package is stable for all Deep Learning workloads tested so far.