### PR TITLE
Use LinkOrCopyStrategy instead of LinkStrategy

### DIFF
--- a/src/nvidia-docker-plugin/plugin_volume.go
+++ b/src/nvidia-docker-plugin/plugin_volume.go
@@ -78,7 +78,7 @@ func (p *pluginVolume) create(resp http.ResponseWriter, req *http.Request) {
 	ok, err := volume.Exists()
 	assert(err)
 	if !ok {
-		assert(volume.Create(nvidia.LinkStrategy{}))
+		assert(volume.Create(nvidia.LinkOrCopyStrategy{}))
 	}
 	assert(json.NewEncoder(resp).Encode(r))
 }


### PR DESCRIPTION
`nvidia-docker-plugin` says we can set path where to store the volumes by using `-d <path>`, but if our specific path is cross partition, it will raise an error while performing a hard link.

This patch try to fix the above problem.

Signed-off-by: thomassong <thomassong@tencent.com>