### PR TITLE
Fix installation instructions for ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Assuming the NVIDIA drivers and Docker are properly installed (see [installation
 #### _Ubuntu distributions_
 ```sh
 # Install nvidia-docker and nvidia-docker-plugin
-wget -P /tmp https://github.com/NVIDIA/nvidia-docker/releases/download/v1.0.1/nvidia-docker_1.0.1-1_amd64.deb
-sudo dpkg -i /tmp/nvidia-docker*.deb && rm /tmp/nvidia-docker*.deb
+wget -O /tmp/nvidia-docker.deb https://github.com/NVIDIA/nvidia-docker/releases/download/v1.0.1/nvidia-docker_1.0.1-1_amd64.deb
+sudo dpkg -i /tmp/nvidia-docker.deb && rm /tmp/nvidia-docker.deb
 
 # Test nvidia-smi
 nvidia-docker run --rm nvidia/cuda nvidia-smi


### PR DESCRIPTION
Because of redirect, the current installation method downloads file to inappropriate location, specifically:

/tmp/d4efc7cc-ff73-11e6-91a2-ce84b8670fcd?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20170709%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20170709T105028Z&X-Amz-Expires=300&X-Amz-Signature=02538a3c63ff9ffcbe9a3cc

This makes dpkg command to fail.. I fix it by using `-O` flag and marking exact output location.
