### PR TITLE
update ppc64le centos image name

### DIFF
--- a/Dockerfile.rpm.ppc64le
+++ b/Dockerfile.rpm.ppc64le
@@ -1,4 +1,4 @@
-FROM ppc64le/centos:7
+FROM ibmcom/centos-ppc64le:7
 
 RUN yum install -y \
         vim \


### PR DESCRIPTION
Unofficial docker images were moved from ppc64le to
ibmcom/imageX-ppc64le.

Signed-off-by: Christy Perez <christy@linux.vnet.ibm.com>