### PR TITLE
add amazon linux as a dist. uses docker instead of docker-ce as rpm dep

### DIFF
--- a/Dockerfile.amzn1
+++ b/Dockerfile.amzn1
@@ -1,0 +1,36 @@
+FROM amazonlinux:latest
+
+# packaging dependencies
+RUN yum install -y \
+        rpm-build && \
+    rm -rf /var/cache/yum/*
+
+# packaging
+ARG PKG_VERS
+ARG PKG_REV
+ARG RUNTIME_VERSION
+ARG DOCKER_VERSION
+
+ENV VERSION $PKG_VERS
+ENV RELEASE $PKG_REV
+ENV RUNTIME_VERSION $RUNTIME_VERSION
+ENV DOCKER_VERSION $DOCKER_VERSION
+
+# output directory
+ENV DIST_DIR=/tmp/nvidia-container-runtime-$PKG_VERS/SOURCES
+RUN mkdir -p $DIST_DIR
+
+COPY nvidia-docker $DIST_DIR
+COPY daemon.json $DIST_DIR
+
+WORKDIR $DIST_DIR/..
+COPY rpm .
+
+CMD rpmbuild --clean -bb \
+             -D "_topdir $PWD" \
+             -D "version $VERSION" \
+             -D "release $RELEASE" \
+             -D "runtime_version $RUNTIME_VERSION" \
+             -D "docker_version $DOCKER_VERSION" \
+             SPECS/nvidia-docker2.spec && \
+    mv RPMS/noarch/*.rpm /dist

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,13 @@ DIST_DIR  := $(CURDIR)/dist
 .NOTPARALLEL:
 .PHONY: all
 
-all: xenial centos7 stretch
+all: xenial centos7 stretch amzn1
 
 xenial: 17.12.0-xenial 17.09.1-xenial 17.09.0-xenial 17.06.2-xenial 17.03.2-xenial 1.13.1-xenial 1.12.6-xenial
 
 centos7: 17.12.0.ce-centos7 17.09.1.ce-centos7 17.09.0.ce-centos7 17.06.2.ce-centos7 17.03.2.ce-centos7 1.13.1-centos7 1.12.6-centos7
+
+amzn1: 17.12.0.ce-amzn1 17.09.1.ce-amzn1 17.09.0.ce-amzn1 17.06.2.ce-amzn1 17.03.2.ce-amzn1 1.13.1-amzn1 1.12.6-amzn1
 
 stretch: 17.12.0-stretch 17.09.1-stretch 17.09.0-stretch 17.06.2-stretch 17.03.2-stretch
 
@@ -170,3 +172,59 @@ stretch: 17.12.0-stretch 17.09.1-stretch 17.09.0-stretch 17.06.2-stretch 17.03.2
                         --build-arg PKG_REV="$(PKG_REV)" \
                         -t nvidia-docker2:$@ -f Dockerfile.stretch .
 	$(DOCKER) run --rm -v $(DIST_DIR)/stretch:/dist:Z nvidia-docker2:$@
+
+17.12.0.ce-amzn1:
+	$(DOCKER) build --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)-1.docker17.12.0" \
+                        --build-arg DOCKER_VERSION="docker = 17.12.0.ce" \
+                        --build-arg PKG_VERS="$(VERSION)" \
+                        --build-arg PKG_REV="$(PKG_REV).docker17.12.0.ce" \
+                        -t nvidia-docker2:$@ -f Dockerfile.amzn1 .
+	$(DOCKER) run --rm -v $(DIST_DIR)/amzn1:/dist:Z nvidia-docker2:$@
+
+17.09.1.ce-amzn1:
+	$(DOCKER) build --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)-1.docker17.09.1" \
+                        --build-arg DOCKER_VERSION="docker = 17.09.1.ce" \
+                        --build-arg PKG_VERS="$(VERSION)" \
+                        --build-arg PKG_REV="$(PKG_REV).docker17.09.1.ce" \
+                        -t nvidia-docker2:$@ -f Dockerfile.amzn1 .
+	$(DOCKER) run --rm -v $(DIST_DIR)/amzn1:/dist:Z nvidia-docker2:$@
+
+17.09.0.ce-amzn1:
+	$(DOCKER) build --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)-1.docker17.09.0" \
+                        --build-arg DOCKER_VERSION="docker = 17.09.0.ce" \
+                        --build-arg PKG_VERS="$(VERSION)" \
+                        --build-arg PKG_REV="$(PKG_REV).docker17.09.0.ce" \
+                        -t nvidia-docker2:$@ -f Dockerfile.amzn1 .
+	$(DOCKER) run --rm -v $(DIST_DIR)/amzn1:/dist:Z nvidia-docker2:$@
+
+17.06.2.ce-amzn1:
+	$(DOCKER) build --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)-1.docker17.06.2" \
+                        --build-arg DOCKER_VERSION="docker = 17.06.2.ce" \
+                        --build-arg PKG_VERS="$(VERSION)" \
+                        --build-arg PKG_REV="$(PKG_REV).docker17.06.2.ce" \
+                        -t nvidia-docker2:$@ -f Dockerfile.amzn1 .
+	$(DOCKER) run --rm -v $(DIST_DIR)/amzn1:/dist:Z nvidia-docker2:$@
+
+17.03.2.ce-amzn1:
+	$(DOCKER) build --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)-1.docker17.03.2" \
+                        --build-arg DOCKER_VERSION="docker = 17.03.2.ce" \
+                        --build-arg PKG_VERS="$(VERSION)" \
+                        --build-arg PKG_REV="$(PKG_REV).docker17.03.2.ce" \
+                        -t nvidia-docker2:$@ -f Dockerfile.amzn1 .
+	$(DOCKER) run --rm -v $(DIST_DIR)/amzn1:/dist:Z nvidia-docker2:$@
+
+1.13.1-amzn1:
+	$(DOCKER) build --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)-1.docker1.13.1" \
+                        --build-arg DOCKER_VERSION="docker = 2:1.13.1" \
+                        --build-arg PKG_VERS="$(VERSION)" \
+                        --build-arg PKG_REV="$(PKG_REV).docker1.13.1" \
+                        -t nvidia-docker2:$@ -f Dockerfile.amzn1 .
+	$(DOCKER) run --rm -v $(DIST_DIR)/amzn1:/dist:Z nvidia-docker2:$@
+
+1.12.6-amzn1:
+	$(DOCKER) build --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)-1.docker1.12.6" \
+                        --build-arg DOCKER_VERSION="docker = 2:1.12.6" \
+                        --build-arg PKG_VERS="$(VERSION)" \
+                        --build-arg PKG_REV="$(PKG_REV).docker1.12.6" \
+                        -t nvidia-docker2:$@ -f Dockerfile.amzn1 .
+	$(DOCKER) run --rm -v $(DIST_DIR)/amzn1:/dist:Z nvidia-docker2:$@

--- a/Makefile
+++ b/Makefile
@@ -189,14 +189,6 @@ stretch: 17.12.0-stretch 17.09.1-stretch 17.09.0-stretch 17.06.2-stretch 17.03.2
                         -t nvidia-docker2:$@ -f Dockerfile.amzn1 .
 	$(DOCKER) run --rm -v $(DIST_DIR)/amzn1:/dist:Z nvidia-docker2:$@
 
-17.09.0.ce-amzn1:
-	$(DOCKER) build --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)-1.docker17.09.0" \
-                        --build-arg DOCKER_VERSION="docker = 17.09.0.ce" \
-                        --build-arg PKG_VERS="$(VERSION)" \
-                        --build-arg PKG_REV="$(PKG_REV).docker17.09.0.ce" \
-                        -t nvidia-docker2:$@ -f Dockerfile.amzn1 .
-	$(DOCKER) run --rm -v $(DIST_DIR)/amzn1:/dist:Z nvidia-docker2:$@
-
 17.06.2.ce-amzn1:
 	$(DOCKER) build --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)-1.docker17.06.2" \
                         --build-arg DOCKER_VERSION="docker = 17.06.2.ce" \
@@ -210,21 +202,5 @@ stretch: 17.12.0-stretch 17.09.1-stretch 17.09.0-stretch 17.06.2-stretch 17.03.2
                         --build-arg DOCKER_VERSION="docker = 17.03.2.ce" \
                         --build-arg PKG_VERS="$(VERSION)" \
                         --build-arg PKG_REV="$(PKG_REV).docker17.03.2.ce" \
-                        -t nvidia-docker2:$@ -f Dockerfile.amzn1 .
-	$(DOCKER) run --rm -v $(DIST_DIR)/amzn1:/dist:Z nvidia-docker2:$@
-
-1.13.1-amzn1:
-	$(DOCKER) build --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)-1.docker1.13.1" \
-                        --build-arg DOCKER_VERSION="docker = 2:1.13.1" \
-                        --build-arg PKG_VERS="$(VERSION)" \
-                        --build-arg PKG_REV="$(PKG_REV).docker1.13.1" \
-                        -t nvidia-docker2:$@ -f Dockerfile.amzn1 .
-	$(DOCKER) run --rm -v $(DIST_DIR)/amzn1:/dist:Z nvidia-docker2:$@
-
-1.12.6-amzn1:
-	$(DOCKER) build --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)-1.docker1.12.6" \
-                        --build-arg DOCKER_VERSION="docker = 2:1.12.6" \
-                        --build-arg PKG_VERS="$(VERSION)" \
-                        --build-arg PKG_REV="$(PKG_REV).docker1.12.6" \
                         -t nvidia-docker2:$@ -f Dockerfile.amzn1 .
 	$(DOCKER) run --rm -v $(DIST_DIR)/amzn1:/dist:Z nvidia-docker2:$@


### PR DESCRIPTION
Install [fails](https://github.com/NVIDIA/nvidia-docker/issues/618) on Amazon Linux AMIs. 