### PR TITLE
Add support for Trusty

### DIFF
--- a/Dockerfile.trusty
+++ b/Dockerfile.trusty
@@ -1,0 +1,40 @@
+FROM ubuntu:trusty
+
+# packaging dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        dh-make \
+        fakeroot \
+        build-essential \
+        devscripts && \
+    rm -rf /var/lib/apt/lists/*
+
+# packaging
+ARG PKG_VERS
+ARG PKG_REV
+ARG RUNTIME_VERSION
+ARG DOCKER_VERSION
+
+ENV DEBFULLNAME "NVIDIA CORPORATION"
+ENV DEBEMAIL "cudatools@nvidia.com"
+ENV REVISION "$PKG_VERS-$PKG_REV"
+ENV RUNTIME_VERSION $RUNTIME_VERSION
+ENV DOCKER_VERSION $DOCKER_VERSION
+ENV DISTRIB "UNRELEASED"
+ENV SECTION ""
+
+# output directory
+ENV DIST_DIR=/tmp/nvidia-docker2-$PKG_VERS
+RUN mkdir -p $DIST_DIR
+
+# nvidia-docker 2.0
+COPY nvidia-docker $DIST_DIR/nvidia-docker
+COPY daemon.json $DIST_DIR/daemon.json
+
+WORKDIR $DIST_DIR
+COPY debian ./debian
+
+RUN dch --create --package nvidia-docker2 -v "$REVISION" "v$REVISION" -D "$DISTRIB" && \
+    dch -r ""
+
+CMD debuild --preserve-env --dpkg-buildpackage-hook='sh debian/prepare' -i -us -uc -b && \
+    mv /tmp/*.deb /dist

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,71 @@ DIST_DIR  := $(CURDIR)/dist
 .NOTPARALLEL:
 .PHONY: all
 
-all: xenial centos7 stretch
+all: trusty xenial centos7 stretch
+
+trusty: 17.12.0-trusty 17.09.1-trusty 17.09.0-trusty 17.06.2-trusty 17.03.2-trusty 1.13.1-trusty 1.12.6-trusty
 
 xenial: 17.12.0-xenial 17.09.1-xenial 17.09.0-xenial 17.06.2-xenial 17.03.2-xenial 1.13.1-xenial 1.12.6-xenial
 
 centos7: 17.12.0.ce-centos7 17.09.1.ce-centos7 17.09.0.ce-centos7 17.06.2.ce-centos7 17.03.2.ce-centos7 1.13.1-centos7 1.12.6-centos7
 
 stretch: 17.12.0-stretch 17.09.1-stretch 17.09.0-stretch 17.06.2-stretch 17.03.2-stretch
+
+17.12.0-trusty:
+	$(DOCKER) build --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)+docker17.12.0-1" \
+                        --build-arg DOCKER_VERSION="docker-ce (= 17.12.0~ce-0~ubuntu) | docker-ee (= 17.12.0~ee-0~ubuntu)" \
+                        --build-arg PKG_VERS="$(VERSION)+docker17.12.0" \
+                        --build-arg PKG_REV="$(PKG_REV)" \
+                        -t nvidia-docker2:$@ -f Dockerfile.trusty .
+	$(DOCKER) run --rm -v $(DIST_DIR)/trusty:/dist:Z nvidia-docker2:$@
+
+17.09.1-trusty:
+	$(DOCKER) build --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)+docker17.09.1-1" \
+                        --build-arg DOCKER_VERSION="docker-ce (= 17.09.1~ce-0~ubuntu) | docker-ee (= 17.09.1~ee-0~ubuntu)" \
+                        --build-arg PKG_VERS="$(VERSION)+docker17.09.1" \
+                        --build-arg PKG_REV="$(PKG_REV)" \
+                        -t nvidia-docker2:$@ -f Dockerfile.trusty .
+	$(DOCKER) run --rm -v $(DIST_DIR)/trusty:/dist:Z nvidia-docker2:$@
+
+17.09.0-trusty:
+	$(DOCKER) build --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)+docker17.09.0-1" \
+                        --build-arg DOCKER_VERSION="docker-ce (= 17.09.0~ce-0~ubuntu) | docker-ee (= 17.09.0~ee-0~ubuntu)" \
+                        --build-arg PKG_VERS="$(VERSION)+docker17.09.0" \
+                        --build-arg PKG_REV="$(PKG_REV)" \
+                        -t nvidia-docker2:$@ -f Dockerfile.trusty .
+	$(DOCKER) run --rm -v $(DIST_DIR)/trusty:/dist:Z nvidia-docker2:$@
+
+17.06.2-trusty:
+	$(DOCKER) build --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)+docker17.06.2-1" \
+                        --build-arg DOCKER_VERSION="docker-ce (= 17.06.2~ce-0~ubuntu) | docker-ee (= 17.06.2~ee-0~ubuntu)" \
+                        --build-arg PKG_VERS="$(VERSION)+docker17.06.2" \
+                        --build-arg PKG_REV="$(PKG_REV)" \
+                        -t nvidia-docker2:$@ -f Dockerfile.trusty .
+	$(DOCKER) run --rm -v $(DIST_DIR)/trusty:/dist:Z nvidia-docker2:$@
+
+17.03.2-trusty:
+	$(DOCKER) build --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)+docker17.03.2-1" \
+                        --build-arg DOCKER_VERSION="docker-ce (= 17.03.2~ce-0~ubuntu-trusty) | docker-ee (= 17.03.2~ee-0~ubuntu-trusty)" \
+                        --build-arg PKG_VERS="$(VERSION)+docker17.03.2" \
+                        --build-arg PKG_REV="$(PKG_REV)" \
+                        -t nvidia-docker2:$@ -f Dockerfile.trusty .
+	$(DOCKER) run --rm -v $(DIST_DIR)/trusty:/dist:Z nvidia-docker2:$@
+
+1.13.1-trusty:
+	$(DOCKER) build --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)+docker1.13.1-1" \
+                        --build-arg DOCKER_VERSION="docker-engine (= 1.13.1-0~ubuntu-trusty) | docker.io (= 1.13.1-0ubuntu1~16.04.2)" \
+                        --build-arg PKG_VERS="$(VERSION)+docker1.13.1" \
+                        --build-arg PKG_REV="$(PKG_REV)" \
+                        -t nvidia-docker2:$@ -f Dockerfile.trusty .
+	$(DOCKER) run --rm -v $(DIST_DIR)/trusty:/dist:Z nvidia-docker2:$@
+
+1.12.6-trusty:
+	$(DOCKER) build --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)+docker1.12.6-1" \
+                        --build-arg DOCKER_VERSION="docker-engine (= 1.12.6-0~ubuntu-trusty) | docker.io (= 1.12.6-0ubuntu1~16.04.1)" \
+                        --build-arg PKG_VERS="$(VERSION)+docker1.12.6" \
+                        --build-arg PKG_REV="$(PKG_REV)" \
+                        -t nvidia-docker2:$@ -f Dockerfile.trusty .
+	$(DOCKER) run --rm -v $(DIST_DIR)/trusty:/dist:Z nvidia-docker2:$@
 
 17.12.0-xenial:
 	$(DOCKER) build --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)+docker17.12.0-1" \

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ stretch: 17.12.0-stretch 17.09.1-stretch 17.09.0-stretch 17.06.2-stretch 17.03.2
 
 1.13.1-trusty:
 	$(DOCKER) build --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)+docker1.13.1-1" \
-                        --build-arg DOCKER_VERSION="docker-engine (= 1.13.1-0~ubuntu-trusty) | docker.io (= 1.13.1-0ubuntu1~16.04.2)" \
+                        --build-arg DOCKER_VERSION="docker-engine (= 1.13.1-0~ubuntu-trusty)" \
                         --build-arg PKG_VERS="$(VERSION)+docker1.13.1" \
                         --build-arg PKG_REV="$(PKG_REV)" \
                         -t nvidia-docker2:$@ -f Dockerfile.trusty .
@@ -71,7 +71,7 @@ stretch: 17.12.0-stretch 17.09.1-stretch 17.09.0-stretch 17.06.2-stretch 17.03.2
 
 1.12.6-trusty:
 	$(DOCKER) build --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)+docker1.12.6-1" \
-                        --build-arg DOCKER_VERSION="docker-engine (= 1.12.6-0~ubuntu-trusty) | docker.io (= 1.12.6-0ubuntu1~16.04.1)" \
+                        --build-arg DOCKER_VERSION="docker-engine (= 1.12.6-0~ubuntu-trusty)" \
                         --build-arg PKG_VERS="$(VERSION)+docker1.12.6" \
                         --build-arg PKG_REV="$(PKG_REV)" \
                         -t nvidia-docker2:$@ -f Dockerfile.trusty .


### PR DESCRIPTION
This PR adds support for Ubuntu Trusty. It adds a `Dockerfile.trusty`, as well as the required build steps in the `Makefile`. The `Dockerfile.trusty` is identical to `Dockerfile.xenial`, apart from the base image (`FROM ubuntu:trusty`).

I've successfully tested this on Trusty with Docker 1.12.6 and 17.9.0. There are corresponding PRs to NVIDIA/libnvidia-container#14 and NVIDIA/nvidia-container-runtime#10.

This PR is submitted on behalf of Spotify. I'm currently checking whether we have already signed a CLA, or whether that still needs to be done.