### PR TITLE
add ubuntu18.04 target (issue #666)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ DIST_DIR  := $(CURDIR)/dist
 
 all: ubuntu18.04 ubuntu16.04 ubuntu14.04 debian9 debian8 centos7 amzn2 amzn1
 
-ubuntu18.04: $(addsuffix -ubuntu18.04, 17.03.2)
+ubuntu18.04: $(addsuffix -ubuntu18.04, 18.03.0 17.03.2)
 
 ubuntu16.04: $(addsuffix -ubuntu16.04, 18.03.0 17.12.1 17.12.0 17.09.1 17.09.0 17.06.2 17.03.2 1.13.1 1.12.6)
 
@@ -44,6 +44,16 @@ amzn1: $(addsuffix -amzn1, 17.09.1.ce 17.06.2.ce 17.03.2.ce)
                         --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)+docker17.03.2-1" \
                         --build-arg DOCKER_VERSION="docker-ce (= 17.03.2ce-0~ubuntu-xenial) | docker.io (= 17.03.2-0ubuntu5)" \
                         --build-arg PKG_VERS="$(VERSION)+docker17.03.2" \
+                        --build-arg PKG_REV="$(PKG_REV)" \
+                        -t "nvidia/nvidia-docker2/ubuntu:18.04-docker$*" -f Dockerfile.ubuntu .
+	$(DOCKER) run --rm -v $(DIST_DIR)/ubuntu18.04:/dist:Z "nvidia/nvidia-docker2/ubuntu:18.04-docker$*"
+
+
+18.03.0-ubuntu18.04:
+	$(DOCKER) build --build-arg VERSION_ID="18.04" \
+                        --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)+docker17.03.2-1" \
+                        --build-arg DOCKER_VERSION="docker-ce (= 18.03.0~ce-0~ubuntu) | docker.io (= 18.03.0)" \
+                        --build-arg PKG_VERS="$(VERSION)+docker18.03.0" \
                         --build-arg PKG_REV="$(PKG_REV)" \
                         -t "nvidia/nvidia-docker2/ubuntu:18.04-docker$*" -f Dockerfile.ubuntu .
 	$(DOCKER) run --rm -v $(DIST_DIR)/ubuntu18.04:/dist:Z "nvidia/nvidia-docker2/ubuntu:18.04-docker$*"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,9 @@ DIST_DIR  := $(CURDIR)/dist
 .NOTPARALLEL:
 .PHONY: all
 
-all: ubuntu16.04 ubuntu14.04 debian9 debian8 centos7 amzn2 amzn1
+all: ubuntu18.04 ubuntu16.04 ubuntu14.04 debian9 debian8 centos7 amzn2 amzn1
+
+ubuntu18.04: $(addsuffix -ubuntu18.04, 17.03.2)
 
 ubuntu16.04: $(addsuffix -ubuntu16.04, 18.03.0 17.12.1 17.12.0 17.09.1 17.09.0 17.06.2 17.03.2 1.13.1 1.12.6)
 
@@ -36,6 +38,16 @@ amzn1: $(addsuffix -amzn1, 17.09.1.ce 17.06.2.ce 17.03.2.ce)
                         --build-arg PKG_REV="$(PKG_REV)" \
                         -t "nvidia/nvidia-docker2/ubuntu:16.04-docker$*" -f Dockerfile.ubuntu .
 	$(DOCKER) run --rm -v $(DIST_DIR)/ubuntu16.04:/dist:Z "nvidia/nvidia-docker2/ubuntu:16.04-docker$*"
+
+17.03.2-ubuntu18.04:
+	$(DOCKER) build --build-arg VERSION_ID="18.04" \
+                        --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)+docker17.03.2-1" \
+                        --build-arg DOCKER_VERSION="docker-ce (= 17.03.2ce-0~ubuntu-xenial) | docker.io (= 17.03.2-0ubuntu5)" \
+                        --build-arg PKG_VERS="$(VERSION)+docker17.03.2" \
+                        --build-arg PKG_REV="$(PKG_REV)" \
+                        -t "nvidia/nvidia-docker2/ubuntu:18.04-docker$*" -f Dockerfile.ubuntu .
+	$(DOCKER) run --rm -v $(DIST_DIR)/ubuntu18.04:/dist:Z "nvidia/nvidia-docker2/ubuntu:18.04-docker$*"
+
 
 17.03.2-ubuntu16.04:
 	$(DOCKER) build --build-arg VERSION_ID="16.04" \


### PR DESCRIPTION
depends on https://github.com/NVIDIA/nvidia-container-runtime/pull/23 which is unfortunately not fully complete yet.