### PR TITLE
Fix docker reloading instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ sudo apt-get update
 
 # Install nvidia-docker2 and reload the Docker daemon configuration
 sudo apt-get install -y nvidia-docker2
-sudo pkill -SIGHUP dockerd
+sudo systemctl daemon-reload
+sudo systemctl restart docker
 
 # Test nvidia-smi with the latest official CUDA image
 docker run --runtime=nvidia --rm nvidia/cuda:9.0-base nvidia-smi
@@ -59,7 +60,8 @@ curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.re
 
 # Install nvidia-docker2 and reload the Docker daemon configuration
 sudo yum install -y nvidia-docker2
-sudo pkill -SIGHUP dockerd
+sudo systemctl daemon-reload
+sudo systemctl restart docker
 
 # Test nvidia-smi with the latest official CUDA image
 docker run --runtime=nvidia --rm nvidia/cuda:9.0-base nvidia-smi


### PR DESCRIPTION
The current post install docker reload instructions don't seem to reload correctly and produce `docker: Error response from daemon: Unknown runtime specified nvidia.` error. This [issue](https://github.com/NVIDIA/nvidia-docker/issues/838) has a fix that solves the problem. I've replaced the instructions for reloading with the suggested instructions from the solution in the issue.