### PR TITLE
centos rpm build should respect runtime version demand

### DIFF
--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -32,5 +32,6 @@ CMD rpmbuild --clean -bb \
              -D "version $VERSION" \
              -D "release $RELEASE" \
              -D "docker_version $DOCKER_VERSION" \
+             -D "runtime_version $RUNTIME_VERSION" \
              SPECS/nvidia-docker2.spec && \
     mv RPMS/noarch/*.rpm /dist


### PR DESCRIPTION
@cdesiniotis @RenaudWasTaken PTAL
Needed for centos case where nvidia-docker2 update does not update nvidia-container-runtime.
This happens alright for amzn-linux apparently, and for ubuntu, just not for centos.