### PR TITLE
Include docker-compose warning in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ The NVIDIA Container Toolkit allows users to build and run GPU accelerated Docke
 **Note that you do not need to install the CUDA toolkit on the host, but the driver needs to be installed**
 
 Note that with the release of Docker 19.03, usage of nvidia-docker2 packages are deprecated since NVIDIA GPUs are now natively supported as devices in the Docker runtime.
+
+**Please note that this native GPU support has not landed in docker-compose yet. Refer to [this issue](https://github.com/docker/compose/issues/6691) for discussion.**
+
 If you are an existing user of the nvidia-docker2 packages, review the instructions in the [“Upgrading with nvidia-docker2” section](https://github.com/NVIDIA/nvidia-docker/tree/master#upgrading-with-nvidia-docker2-deprecated).
+
 
 For first-time users of Docker 19.03 and GPUs, continue with the instructions for getting started below.
 


### PR DESCRIPTION
The native docker support for NVIDIA GPUs has not landed in docker-compose yet. Knowing this would have saved me quite some time debugging, so I'm confident that this hint should be useful for others.