### PR TITLE
[README] Revert bad replace in docker version. 110.03->19.03

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ The NVIDIA Container Toolkit allows users to build and run GPU accelerated Docke
 
 ## Quickstart
 
-**Make sure you have installed the [NVIDIA driver](https://github.com/NVIDIA/nvidia-docker/wiki/Frequently-Asked-Questions#how-do-i-install-the-nvidia-driver) and Docker 110.03 for your Linux distribution**
+**Make sure you have installed the [NVIDIA driver](https://github.com/NVIDIA/nvidia-docker/wiki/Frequently-Asked-Questions#how-do-i-install-the-nvidia-driver) and Docker 19.03 for your Linux distribution**
 **Note that you do not need to install the CUDA toolkit on the host, but the driver needs to be installed**
 
-Note that with the release of Docker 110.03, usage of nvidia-docker2 packages are deprecated since NVIDIA GPUs are now natively supported as devices in the Docker runtime.
+Note that with the release of Docker 19.03, usage of nvidia-docker2 packages are deprecated since NVIDIA GPUs are now natively supported as devices in the Docker runtime.
 
 **Please note that this native GPU support has not landed in docker-compose yet. Refer to [this issue](https://github.com/docker/compose/issues/6691) for discussion.**
 
 If you are an existing user of the nvidia-docker2 packages, review the instructions in the [“Upgrading with nvidia-docker2” section](https://github.com/NVIDIA/nvidia-docker/tree/master#upgrading-with-nvidia-docker2-deprecated).
 
-For first-time users of Docker 110.03 and GPUs, continue with the instructions for getting started below.
+For first-time users of Docker 19.03 and GPUs, continue with the instructions for getting started below.
 
 ### Ubuntu 16.04/18.04, Debian Jessie/Stretch/Buster
 ```sh
@@ -49,9 +49,9 @@ Since openSUSE Leap 15.1 still has Docker 18.06, you have two options:
 **Option 1**: use the `Virtualization:containers` repository to fetch a more recent version of Docker
 
 ```console
-# Upgrade Docker to 110.03+ first:
+# Upgrade Docker to 19.03+ first:
 zypper ar https://download.opensuse.org/repositories/Virtualization:/containers/openSUSE_Leap_15.1/Virtualization:containers.repo
-zypper install --allow-vendor-change 'docker >= 110.03'  # accept the new signature
+zypper install --allow-vendor-change 'docker >= 19.03'  # accept the new signature
 
 # Add the package repositories
 distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
@@ -118,8 +118,8 @@ More information on the environment variables are available [on this page](https
 
 ## Upgrading with nvidia-docker2 (Deprecated)
 
-If you are running an old version of docker (< 110.03) check the instructions on installing the [`nvidia-docker2`](https://github.com/NVIDIA/nvidia-docker/wiki/Installation-(version-2.0)) package which supports Docker >= 1.12.
-If you already have the old package installed (nvidia-docker2), updating to the latest Docker version (>= 110.03) will still work and will  give you access to the new CLI options for supporting GPUs:
+If you are running an old version of docker (< 19.03) check the instructions on installing the [`nvidia-docker2`](https://github.com/NVIDIA/nvidia-docker/wiki/Installation-(version-2.0)) package which supports Docker >= 1.12.
+If you already have the old package installed (nvidia-docker2), updating to the latest Docker version (>= 19.03) will still work and will  give you access to the new CLI options for supporting GPUs:
 
 ```
 # On debian based distributions: Ubuntu / Debian


### PR DESCRIPTION
The commit bf3d3d1 three days ago updated the `README` page to use CUDA 10. 

However, in the process, the required docker version (`19.03`) was replaced by `110.03`, that does not exists. This MR reverts those spurious changes, that could confuse the readers.

I believe this was caused by quick search-and-replace from 9 to 10.